### PR TITLE
Add Verbs v0.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "hirethunk/verbs": "^0.5.1 || dev-main"
+        "hirethunk/verbs": "^0.5.1|^0.6|dev-main"
     },
     "require-dev": {
         "laravel/pint": "^1.13",


### PR DESCRIPTION
Currently we can't install the latest version of Verbs and Verbs History together, do to semver treating v0.x version changes are major versions.

So this PR adds support for Verbs v0.6